### PR TITLE
ci: test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,5 @@ jobs:
 
       - name: Merge PR
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}  # Assuming PAT_TOKEN is your secret name
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: gh pr merge ${{ github.event.pull_request.number }} --merge


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use the correct secret name `PAT_TOKEN` when merging pull requests.